### PR TITLE
Modify financial_year function for dates occurring in January to March

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     rlang,
     stats,
     stringr,
+    tibble,
     tidyr,
     tidyselect,
     utils

--- a/R/date_tools.R
+++ b/R/date_tools.R
@@ -35,17 +35,16 @@ convert_col_date <- function(data, input_format = "%Y-%m",output_format = "%B %Y
 #' Convert Date into Financial Year
 #'
 #' This function takes a date object as input, and outputs string corresponding to
-#' financial year. Defaults to counting financial year start as 1 April.
+#' financial year starting at 1 April.
 #' @param date Date to be converted to new format
-#' @param fin_year_start_day First day of financial year. Defaults to 1.
-#' @param fin_year_start_month First month of financial year. Defaults to 4 (i.e. April).
 #' @export
 
-financial_year <- function(date, fin_year_start_day = 1, fin_year_start_month = 4){
-  dplyr::case_when(lubridate::month(date) + lubridate::day(date) <
-      fin_year_start_month + 0.01 * fin_year_start_day ~
-      paste0(lubridate::year(date) - 1, "-", lubridate::year(date)),
-  .default = paste0(lubridate::year(date), "-", lubridate::year(date) + 1))
+financial_year <- function(date) {
+  dplyr::if_else(
+    lubridate::month(date) <= 3,
+    paste0(lubridate::year(date) - 1, "-", lubridate::year(date)),
+    paste0(lubridate::year(date), "-", lubridate::year(date) + 1)
+  )
 }
 
 #' Create standard calendar with Scottish bank holidays

--- a/man/financial_year.Rd
+++ b/man/financial_year.Rd
@@ -4,16 +4,12 @@
 \alias{financial_year}
 \title{Convert Date into Financial Year}
 \usage{
-financial_year(date, fin_year_start_day = 1, fin_year_start_month = 4)
+financial_year(date)
 }
 \arguments{
 \item{date}{Date to be converted to new format}
-
-\item{fin_year_start_day}{First day of financial year. Defaults to 1.}
-
-\item{fin_year_start_month}{First month of financial year. Defaults to 4 (i.e. April).}
 }
 \description{
 This function takes a date object as input, and outputs string corresponding to
-financial year. Defaults to counting financial year start as 1 April.
+financial year starting at 1 April.
 }

--- a/tests/testthat/test-date_tools.R
+++ b/tests/testthat/test-date_tools.R
@@ -23,3 +23,19 @@ test_that("convert_col_date() converts a whole column of dates within a datafram
                  dplyr::mutate(dates = convert_col_date(dates)),
                dplyr::tibble(dates = c("November 2024", "December 2024", "January 2025")))
 })
+test_that("financial_year() coverts a data objection into financial year", {
+  test_jan_mar_data <- tibble::tibble(dates = seq(as.Date("2024-01-01"),
+                                                  as.Date("2024-03-31"),
+                                                  by = "day"),
+                                      calculated_fy = financial_year(dates),
+                                      expected_fy = "2023-2024")
+
+  test_apr_dec_data <- tibble::tibble(dates = seq(as.Date("2024-04-01"),
+                                                  as.Date("2024-12-31"),
+                                                  by = "day"),
+                                      calculated_fy = financial_year(dates),
+                                      expected_fy = "2024-2025")
+
+  expect_equal(test_jan_mar_data$calculated_fy, test_jan_mar_data$expected_fy)
+  expect_equal(test_apr_dec_data$calculated_fy, test_apr_dec_data$expected_fy)
+})


### PR DESCRIPTION
**The issue**

When using the `financial_year` function, I received unexpected outputs like below:

|dates|expected|actual|
|------|----------|-------|
|2024-01-04|2023-2024| 2024-2025|
|2024-01-05|2023-2024| 2024-2025|
|2024-02-03|2023-2024| 2024-2025|
|2024-02-04|2023-2024| 2024-2025|
|2024-03-02|2023-2024| 2024-2025|
|2024-03-03|2023-2024| 2024-2025|

**Proposed changes**

I have slightly tweaked the `financial_year` function although this modified function would be perhaps too simplified than its predecessor as this would be fixed for the financial year only and would not be flexible for any year that would start at any different month. In other words, two arguments -- `fin_year_start_day` and `fin_year_start_month` -- are removed, but we can undo this removal

In related to this modified function, I have added tests to ensure this is outputting the correct financial year as expected.

Happy to discuss more.

Ken

