### PR TITLE
Geography update

### DIFF
--- a/R/add_geography.R
+++ b/R/add_geography.R
@@ -5,10 +5,11 @@
 #' Lookup for all Social Security Scotland official statistics publications.
 #' As this lookup does not contain the local authority name, we need to join
 #' the local authority names from the data zone 2022 lookup. To add Scottish
-#' Index of Multiple Deprivation columns the 2011 datazones are needed.
+#' Index of Multiple Deprivation columns the 2011 datazones are needed and these
+#' are obtained from the sspl lookup file.
 #'
-#' Then, after cleaning the postcodes, those geography fields are added to the
-#' target data frame by joining via the postcode column.
+#' After cleaning the postcodes, the geography fields are added to the
+#' target data frame by joining on the postcode column.
 #'
 #' There are some postcodes that cannot be matched to any version of the
 #' Scottish Statistics Postcode lookup, and thus those postcodes cannot be
@@ -27,32 +28,28 @@
 #' For further explanation on the structure of a typical Scottish postcode:
 #'  https://www.nrscotland.gov.uk/publications/geography-postcode-information-note/.
 #'
-#'  Function defaults to using a config file for the path to the sspl file
-#'  (uses config$sspl) but if a path is given as as the third argument in the
-#'  function call then the function will use that instead. This means a config
-#'  file is not essential for use.
+#' The three lookup files can be obtained by using functions from sssstats package
+#' get_sspl_lookup();get_datazone_lookup();get_simd_lookup()
+#'
 #' @importFrom rlang enquo
 #' @importFrom dplyr mutate select left_join filter distinct pull case_when if_else
 #' @importFrom stringr str_replace_all str_replace str_extract str_detect str_to_upper str_trim
 #' @importFrom tidyselect all_of
 #' @param input_data dataset containing the postcode column
+#' @param sspl_lookup the sspl_lookup dataframe
+#' @param datazone_lookup the datazone lookup dataframe
+#' @param simd_lookup the simd lookup dataframe
 #' @param postcode_column column name containing postcode
-#' @param sspl_path (optional) path to sspl file (see description)
+
 #' @return data frame with geography fields added
 #' @export
 
-add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
+add_geography <- function(input_data,
+                          sspl_lookup,
+                          datazone_lookup,
+                          simd_lookup,
+                          postcode_column) {
   postcode_column <- rlang::enquo(postcode_column)
-
-  # gets the config file if there is one
-  # and prevents error if no config
-  config <- tryCatch(
-    config <- config::get(),
-    error = function(e) {
-      message("No config file found", e$message)
-      NULL
-    }
-  )
 
   # lists relevant geography fields from the Scottish Statistics Postcode Lookup
   sspl_keep <- c(
@@ -65,12 +62,6 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
     "intermediate_zone2011code",
     "island_code"
   )
-
-  # gets the lookup file from server
-  lookup_path <- if (!is.null(sspl_path)) sspl_path else config$sspl
-  sspl_lookup <- get_sspl_lookup(lookup_path) |>
-    dplyr::select(tidyselect::all_of(sspl_keep))
-
 
   # Regular expression for a standard UK postcode
   uk_postcode_regex <- "^([A-Z][A-HJ-Y]?\\d[A-Z\\d]? ?\\d[A-Z]{2}|GIR ?0A{2})$"
@@ -97,8 +88,8 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
         FALSE
       ),
       postcode_formatted = dplyr::if_else(valid_uk_postcode == TRUE,
-                                          temp_postcode_formatted,
-                                          NA_character_
+        temp_postcode_formatted,
+        NA_character_
       )
     ) |>
     dplyr::select(
@@ -110,7 +101,7 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
   # - Local authority area (la_name and la_code)
   # - Health board (hb_code and hb_name)
   # - Urban rural classification 8-fold (ur8_code and ur8_name).
-  dz_2022_lookup <- sssstats::get_datazone_lookup("2022") |>
+  dz_2022_lookup <- datazone_lookup |>
     dplyr::select(
       dz22_code,
       la_code,
@@ -124,20 +115,20 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
   # As the current version of Scottish Index of Multiple Deprivation (SIMD) code
   # is based on the 2011 data zone code, uses the SIMD lookup to get the
   # quintile and decile values.
-  simd_lookup <- sssstats::get_simd_lookup() |>
+  simd_lookup <- simd_lookup |>
     dplyr::select(
       ref_area,
       simd_2020_quintile,
       simd_2020_decile
     )
 
-  # Adds geography fields into the Scottish Statistics Postcode Lookup
+  # Adds columns into the Scottish Statistics Postcode Lookup
   sspl_lookup <- sspl_lookup |>
     dplyr::left_join(dz_2022_lookup,
-                     by = c("data_zone2022code" = "dz22_code")
+      by = c("data_zone2022code" = "dz22_code")
     ) |>
     dplyr::left_join(simd_lookup,
-                     by = c("data_zone2011code" = "ref_area")
+      by = c("data_zone2011code" = "ref_area")
     )
 
   # Makes a list of Scottish postcode areas, excluding "CA" as these used to be
@@ -154,7 +145,7 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
   # Adds all necessary geography fields into the input_data object
   data_with_sspl <- input_data_formatted |>
     dplyr::left_join(sspl_lookup,
-                     by = c("postcode_formatted" = "postcode")
+      by = c("postcode_formatted" = "postcode")
     )
 
   # adds suitable labels to the "name" columns for postcodes that cannot be
@@ -167,7 +158,7 @@ add_geography <- function(input_data, postcode_column, sspl_path = NULL) {
           !is.na(.x) ~ .x,
           valid_uk_postcode &
             stringr::str_extract(postcode_formatted, "^[A-Z]+")
-          %in% scottish_postcode_area ~ "Unknown - Scottish postcode",
+            %in% scottish_postcode_area ~ "Unknown - Scottish postcode",
           valid_uk_postcode ~ "Unknown - Non-Scottish postcode",
           TRUE ~ "Unknown - Other"
         )

--- a/R/get_simd_lookup.R
+++ b/R/get_simd_lookup.R
@@ -9,7 +9,7 @@
 
 get_simd_lookup <- function() {
   opendatascot::ods_dataset("scottish-index-of-multiple-deprivation",
-                            simdDomain = "simd"
+    simdDomain = "simd"
   ) |>
     tidyr::unite(
       col = "simd_variable",

--- a/R/get_sspl_lookup.R
+++ b/R/get_sspl_lookup.R
@@ -8,15 +8,13 @@
 #' statistical production to ensure geographic consistency across all official
 #' statistics and to support the implementation of the Government Statistical
 #' Service Geography Policy.
-#' @param folder-path the path to the folder containing the lookup.
+#' @param file-path the path to the sspl lookup file.
 #' @importFrom janitor clean_names
 #' @importFrom readr read_csv
 #' @return A data frame.
 #' @export
 
-get_sspl_lookup<- function(folder_path){
-  the_file <- "SingleRecord.csv"
-  file_path <- paste0(folder_path, "/", the_file)
+get_sspl_lookup<- function(file_path){
 
   if(!file.exists(file_path)){
     stop("File 'SingleRecord.csv' not found in folder: ", folder_path)

--- a/R/get_sspl_lookup.R
+++ b/R/get_sspl_lookup.R
@@ -17,7 +17,7 @@
 get_sspl_lookup<- function(file_path){
 
   if(!file.exists(file_path)){
-    stop("File 'SingleRecord.csv' not found in folder: ", folder_path)
+    stop("File not found: ", file_path)
   }
 
   sspl <- readr::read_csv(file_path) |>

--- a/R/get_sspl_lookup.R
+++ b/R/get_sspl_lookup.R
@@ -14,9 +14,8 @@
 #' @return A data frame.
 #' @export
 
-get_sspl_lookup<- function(file_path){
-
-  if(!file.exists(file_path)){
+get_sspl_lookup <- function(file_path) {
+  if (!file.exists(file_path)) {
     stop("File not found: ", file_path)
   }
 

--- a/man/add_geography.Rd
+++ b/man/add_geography.Rd
@@ -4,14 +4,24 @@
 \alias{add_geography}
 \title{add_geography Adds geography fields from the Scottish Statistics Postcode Lookup}
 \usage{
-add_geography(input_data, postcode_column, sspl_path = NULL)
+add_geography(
+  input_data,
+  sspl_lookup,
+  datazone_lookup,
+  simd_lookup,
+  postcode_column
+)
 }
 \arguments{
 \item{input_data}{dataset containing the postcode column}
 
-\item{postcode_column}{column name containing postcode}
+\item{sspl_lookup}{the sspl_lookup dataframe}
 
-\item{sspl_path}{(optional) path to sspl file (see description)}
+\item{datazone_lookup}{the datazone lookup dataframe}
+
+\item{simd_lookup}{the simd lookup dataframe}
+
+\item{postcode_column}{column name containing postcode}
 }
 \value{
 data frame with geography fields added
@@ -21,10 +31,11 @@ Selects relevant geography fields from the Scottish Statistics Postcode
 Lookup for all Social Security Scotland official statistics publications.
 As this lookup does not contain the local authority name, we need to join
 the local authority names from the data zone 2022 lookup. To add Scottish
-Index of Multiple Deprivation columns the 2011 datazones are needed.
+Index of Multiple Deprivation columns the 2011 datazones are needed and these
+are obtained from the sspl lookup file.
 
-Then, after cleaning the postcodes, those geography fields are added to the
-target data frame by joining via the postcode column.
+After cleaning the postcodes, the geography fields are added to the
+target data frame by joining on the postcode column.
 
 There are some postcodes that cannot be matched to any version of the
 Scottish Statistics Postcode lookup, and thus those postcodes cannot be
@@ -44,8 +55,6 @@ https://www.ons.gov.uk/methodology/geography/ukgeographies/postalgeography.
 For further explanation on the structure of a typical Scottish postcode:
 https://www.nrscotland.gov.uk/publications/geography-postcode-information-note/.
 
-Function defaults to using a config file for the path to the sspl file
-(uses config$sspl) but if a path is given as as the third argument in the
-function call then the function will use that instead. This means a config
-file is not essential for use.
+The three lookup files can be obtained by using functions from sssstats package
+get_sspl_lookup();get_datazone_lookup();get_simd_lookup()
 }

--- a/man/get_sspl_lookup.Rd
+++ b/man/get_sspl_lookup.Rd
@@ -4,10 +4,10 @@
 \alias{get_sspl_lookup}
 \title{get_sspl_lookup Read in the Scottish Statistics Postcode Lookup}
 \usage{
-get_sspl_lookup(folder_path)
+get_sspl_lookup(file_path)
 }
 \arguments{
-\item{folder-path}{the path to the folder containing the lookup.}
+\item{file-path}{the path to the sspl lookup file.}
 }
 \value{
 A data frame.

--- a/tests/testthat/test-add_geography.R
+++ b/tests/testthat/test-add_geography.R
@@ -1,8 +1,4 @@
 test_that("add_geography works", {
-
-  # This test will fail unless you have a config file.
-  # You could type in the path to the server but we can't put that on Github either
-
   test_data <- tibble::tibble(
     postcode = c(
       "AB39 2HP",
@@ -75,8 +71,21 @@ test_that("add_geography works", {
     )
   )
 
+  # setup for the sspl file
+  config <- config::get()
+  folder_path <- config$sspl_folder
+  file_path <- paste0(folder_path, "archive/singlerecord_2025_1.csv")
+
+  # collect all the lookups
+  sspl_lookup <- get_sspl_lookup(file_path)
+  datazone_lookup <- get_datazone_lookup("2022")
+  simd_lookup <- get_simd_lookup()
+
   postcodes_result <- add_geography(
     test_data,
+    sspl_lookup,
+    datazone_lookup,
+    simd_lookup,
     postcode
   )
 

--- a/tests/testthat/test-get_sspl_lookup.R
+++ b/tests/testthat/test-get_sspl_lookup.R
@@ -3,7 +3,7 @@ test_that("get_sspl_lookup works", {
   config <- config::get()
 
   folder_path <- config$sspl_folder
-  file_path<- paste0(folder_path,"archive/singlerecord_2025_1.csv")
+  file_path <- paste0(folder_path, "archive/singlerecord_2025_1.csv")
   sspl_result <- get_sspl_lookup(file_path)
 
   expect_equal(length(unique(sspl_result$data_zone2022code)), 7392)
@@ -15,8 +15,7 @@ test_that("get_sspl_lookup errors correctly", {
   config <- config::get()
 
   folder_path <- config$sspl_folder
-  file_path_bad<- paste0(folder_path,"archive/singlerecord_test.csv")
+  file_path_bad <- paste0(folder_path, "archive/singlerecord_test.csv")
 
   expect_error(get_sspl_lookup(file_path_bad))
-
 })

--- a/tests/testthat/test-get_sspl_lookup.R
+++ b/tests/testthat/test-get_sspl_lookup.R
@@ -1,8 +1,9 @@
 test_that("get_sspl_lookup works", {
-
   # This test will fail without a config file
   config <- config::get()
-  file_path <- config$sspl
+
+  folder_path <- config$sspl_folder
+  file_path<- paste0(folder_path,"archive/singlerecord_2025_1.csv")
   sspl_result <- get_sspl_lookup(file_path)
 
   expect_equal(length(unique(sspl_result$data_zone2022code)), 7392)

--- a/tests/testthat/test-get_sspl_lookup.R
+++ b/tests/testthat/test-get_sspl_lookup.R
@@ -10,3 +10,13 @@ test_that("get_sspl_lookup works", {
   expect_equal(length(unique(sspl_result$intermediate_zone2022code)), 1334)
   expect_equal(length(unique(sspl_result$council_area2019code)), 32)
 })
+
+test_that("get_sspl_lookup errors correctly", {
+  config <- config::get()
+
+  folder_path <- config$sspl_folder
+  file_path_bad<- paste0(folder_path,"archive/singlerecord_test.csv")
+
+  expect_error(get_sspl_lookup(file_path_bad))
+
+})


### PR DESCRIPTION
The main change this makes is to add the lookup files as parameters. The reason for this is to reduce the number of calls made during a pipeline. Supplying the lookup files directly to the function means they can be made as targets only once then used as often as needed. Since the sspl file has datazones in it, we only need the datazone 2022 file now to retrieve the local authority names, 2011 datazone for adding simd columns can be used directly from the sspl file.